### PR TITLE
Create is-discord-member.ts

### DIFF
--- a/apps/core/src/pages/api/is-discord-member.ts
+++ b/apps/core/src/pages/api/is-discord-member.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method === "GET") {
+    const username = req.query.username;
+
+    const response = await fetch(
+      `https://discord.com/api/v9/guilds/${DISCORD_GUILD_ID}/members/search?query=${username}&limit=1000`,
+      {
+        headers: {
+          Authorization: `Bot ${DISCORD_TOKEN}`,
+        },
+      }
+    );
+
+    const searchResults = await response.json();
+
+    const isMember = searchResults.some(
+      (result) => result.user.username === username
+    );
+
+    res.status(200).json(isMember);
+  }
+}


### PR DESCRIPTION
Interview Pen and any other future partners can navigate to https://www.blacc.xyz/api/is-discord-member?username=_________ to check if a user if a member of our server.

The API returns a boolean representing membership in the server.

Example:

https://www.blacc.xyz/api/is-discord-member?username=genyus

returns: true

https://www.blacc.xyz/api/is-discord-member?username=superGenyus

returns: false